### PR TITLE
fix: cria validacao para corrigir erro ao criar declaracao já existente

### DIFF
--- a/src/controllers/DeclaracaoController.ts
+++ b/src/controllers/DeclaracaoController.ts
@@ -201,7 +201,19 @@ class DeclaracaoController {
         .json({ message: "Erro ao buscar declarações pendentes." })
     }
   }
-
+  /**
+ * Cria uma nova declaração ou retifica uma declaração existente, associando-a a um museu e ao responsável.
+ * 
+ * @param {string} req.params.anoDeclaracao - O ano da declaração, fornecido na URL.
+ * @param {string} req.params.museu - O ID do museu associado à declaração, fornecido na URL.
+ * @param {string} req.params.idDeclaracao - O ID da declaração existente que está sendo retificada, se aplicável.
+ * 
+ * @returns {Promise<Response>} - Retorna uma resposta HTTP que contém o status da operação e a declaração criada ou um erro.
+ * 
+ * @throws {400} - Se dados obrigatórios estão ausentes ou o museu não é válido.
+ * @throws {404} - Se a declaração a ser retificada não for encontrada.
+ * @throws {500} - Se ocorrer um erro interno ao processar a declaração.
+ */
   async criarDeclaracao(req: Request, res: Response) {
     try {
         const { anoDeclaracao, museu: museu_id, idDeclaracao } = req.params;

--- a/src/controllers/DeclaracaoController.ts
+++ b/src/controllers/DeclaracaoController.ts
@@ -373,7 +373,14 @@ class DeclaracaoController {
     }
   }
   async uploadDeclaracao(req: Request, res: Response) {
-    delete req.params.idDeclaracao // Remove o idDeclaracao para diferenciar a operação
+    delete req.params.idDeclaracao
+    const declaracaoExistente = await this.declaracaoService.verificarDeclaracaoExistente(req.params.museu,req.params.anoDeclaracao)
+    if (!!declaracaoExistente) {
+      return res.status(406).json({
+        status: false,
+        message: 'Já existe declaração para museu e ano referência informados. Para alterar a declaração é preciso refica-la'
+      });
+    }
     return this.criarDeclaracao(req, res)
   }
 

--- a/src/middlewares/UploadMiddleware.ts
+++ b/src/middlewares/UploadMiddleware.ts
@@ -17,20 +17,20 @@ const upload = multer({ limits: { fieldSize: 1024 * 1024 * 1024 } }).fields([
 
 const uploadMiddleware: RequestHandler = (req, res, next) => {
   upload(req, res, (err: any) => {
-    if (err instanceof MulterError) {
-      return res.status(400).json({ message: 'Erro ao fazer submissão do(s) arquivo(s): ' + err.message });
-    } else if (err instanceof Error) {
-      return res.status(500).json({ message: 'Erro não mapeado ao fazer submissão do(s) arquivo(s): ' + err.message });
+    if (err) {
+      const errorMessage =
+        err instanceof MulterError
+          ? 'Erro ao fazer submissão do(s) arquivo(s): ' + err.message
+          : 'Erro não mapeado ao fazer submissão do(s) arquivo(s): ' + err.message;
+      return res.status(err instanceof MulterError ? 400 : 500).json({ message: errorMessage });
     }
     const uploadReq = req as SubmissionRequest;
 
-    if (
-      !uploadReq.files.arquivistico &&
-      !uploadReq.files.bibliografico &&
-      !uploadReq.files.museologico
-    ) {
-      return res.status(400).json({ message: 'Pelo menos um arquivo deve ser enviado.' });
-    }
+     const { arquivistico, bibliografico, museologico } = uploadReq.files;
+
+  if (!arquivistico && !bibliografico && !museologico) {
+    return res.status(400).json({ message: 'Pelo menos um arquivo deve ser enviado.' });
+  }
 
     next();
   });

--- a/src/middlewares/UploadMiddleware.ts
+++ b/src/middlewares/UploadMiddleware.ts
@@ -12,7 +12,7 @@ const uploadMiddleware: RequestHandler = (req, res, next) => {
       console.log(err)
       return res
         .status(400)
-        .json({ message: "Erro ao fazer upload dos arquivos." })
+        .json({ message: "Erro ao fazer upload dos arquivos:" + err })
     }
     // Verificar se os arquivos foram enviados corretamente
     if (!req.files) {

--- a/src/middlewares/UploadMiddleware.ts
+++ b/src/middlewares/UploadMiddleware.ts
@@ -1,26 +1,39 @@
-import multer from "multer"
-import { RequestHandler } from "express"
+import multer, { MulterError } from 'multer';
+import { Request, RequestHandler } from 'express';
 
-// Crie o middleware de upload para lidar com vários arquivos
-const uploadMiddleware: RequestHandler = (req, res, next) => {
-  multer({ limits: { fieldSize: 1024 * 1024 * 1024 } }).fields([
-    { name: "arquivistico", maxCount: 1 },
-    { name: "bibliografico", maxCount: 1 },
-    { name: "museologico", maxCount: 1 }
-  ])(req, res, (err) => {
-    if (err) {
-      console.log(err)
-      return res
-        .status(400)
-        .json({ message: "Erro ao fazer upload dos arquivos:" + err })
-    }
-    // Verificar se os arquivos foram enviados corretamente
-    if (!req.files) {
-      return res.status(400).json({ message: "Nenhum arquivo enviado." })
-    }
-
-    next()
-  })
+interface SubmissionRequest extends Request {
+  files: {
+    arquivistico?: Express.Multer.File[];
+    bibliografico?: Express.Multer.File[];
+    museologico?: Express.Multer.File[];
+  };
 }
 
-export default uploadMiddleware
+const upload = multer({ limits: { fieldSize: 1024 * 1024 * 1024 } }).fields([
+  { name: 'arquivistico', maxCount: 1 },
+  { name: 'bibliografico', maxCount: 1 },
+  { name: 'museologico', maxCount: 1 },
+]);
+
+const uploadMiddleware: RequestHandler = (req, res, next) => {
+  upload(req, res, (err: any) => {
+    if (err instanceof MulterError) {
+      return res.status(400).json({ message: 'Erro ao fazer submissão do(s) arquivo(s): ' + err.message });
+    } else if (err instanceof Error) {
+      return res.status(500).json({ message: 'Erro não mapeado ao fazer submissão do(s) arquivo(s): ' + err.message });
+    }
+    const uploadReq = req as SubmissionRequest;
+
+    if (
+      !uploadReq.files.arquivistico &&
+      !uploadReq.files.bibliografico &&
+      !uploadReq.files.museologico
+    ) {
+      return res.status(400).json({ message: 'Pelo menos um arquivo deve ser enviado.' });
+    }
+
+    next();
+  });
+};
+
+export default uploadMiddleware;

--- a/src/models/Declaracao.ts
+++ b/src/models/Declaracao.ts
@@ -51,6 +51,7 @@ export interface DeclaracaoModel extends Document {
   versao: number
   createdAt?: Date
   updatedAt?: Date
+  ultimaDeclaracao: boolean
 }
 
 export type ArquivoTypes =
@@ -82,10 +83,12 @@ const DeclaracaoSchema = new Schema<DeclaracaoModel>(
     },
     arquivistico: ArquivoSchema,
     bibliografico: ArquivoSchema,
-    museologico: ArquivoSchema
+    museologico: ArquivoSchema,
+    ultimaDeclaracao: { type: Boolean, default: true }
   },
   { timestamps: true, versionKey: false }
 )
+
 DeclaracaoSchema.pre("save", function (next) {
   if (this.dataCriacao) {
     this.dataCriacao = this.createdAt
@@ -93,6 +96,7 @@ DeclaracaoSchema.pre("save", function (next) {
   this.dataCriacao = new Date()
   next()
 })
+
 export const Declaracoes = mongoose.model<DeclaracaoModel>(
   "Declaracoes",
   DeclaracaoSchema

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -271,7 +271,7 @@ routes.post(
  */
 routes.put(
   "/retificar/:museu/:anoDeclaracao/:idDeclaracao",
-  // uploadMiddleware,
+  uploadMiddleware,
   userMiddleware,
   declaracaoController.retificarDeclaracao.bind(declaracaoController)
 )


### PR DESCRIPTION
Adicionada validação para evitar a criação de declarações duplicadas. Agora, antes de criar uma nova declaração, o sistema verifica se já existe uma declaração para o mesmo museu e ano de referência. Se uma declaração existente for encontrada, o sistema retorna um erro 406 com uma mensagem informando que a declaração já existe.