### PR TITLE
Fix/corrige recibo

### DIFF
--- a/src/service/ReciboService.ts
+++ b/src/service/ReciboService.ts
@@ -283,7 +283,7 @@ async function gerarPDFRecibo(
         },
         { text: "\n\n" },
         { text: dadosFormatados.numeroRecibo, style: "footerReceipt" },
-         { text: "\n\n\n\n\n\n\n\n\n\n" },
+         { text: "\n\n\n\n\n\n\n\n" },
         {text: ` Recibo emitido em ${DataUtils.gerarDataFormatada()} ás ${DataUtils.gerarHoraFormatada()}`,fontSize:11}
       ],
 

--- a/src/utils/dataUtils.ts
+++ b/src/utils/dataUtils.ts
@@ -1,13 +1,17 @@
+import { formatInTimeZone } from 'date-fns-tz'
+
+
 export class DataUtils {
   static getCurrentData() {
     return new Date()
   }
-
-  static gerarDataFormatada(data: Date = new Date()): string {
-    return data.toLocaleDateString("pt-BR")
+  static gerarDataFormatada(data: Date = this.getCurrentData()): string {
+    const timeZone = 'America/Sao_Paulo';
+    return formatInTimeZone(data, timeZone, 'dd/MM/yyyy');
   }
 
-  static gerarHoraFormatada(data: Date = new Date()): string {
-    return data.toLocaleTimeString("pt-BR")
+  static gerarHoraFormatada(data: Date = this.getCurrentData()): string {
+    const timeZone = 'America/Sao_Paulo';
+    return formatInTimeZone(data, timeZone, 'HH:mm:ss');
   }
 }


### PR DESCRIPTION
Identifiquei uma incompatibilidade de horário relacionada à funcionalidade de recibo. Durante os testes locais, tanto a data de recebimento quanto a data de download são exibidas corretamente. Contudo, em produção, os horários estão sendo alterados, provavelmente devido à configuração do servidor com um fuso horário diferente. 

Tratei o timezone corretamente.  e este pull request implementa a correção necessária para garantir que as datas e horas sejam exibidas corretamente.