### PR TITLE
Script de teste e actions

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -75,3 +75,32 @@ jobs:
 
       - name: Executar script de atualização
         run: python ./src/scripts/updatePortainer.py
+      
+      - name: Waiting environment update
+        run: sleep 20
+
+# Testing main flow
+
+  testing_main_flow:
+    needs: updating_environment
+    runs-on: ubuntu-latest
+      steps:
+        - name: Checkout do código
+          uses: actions/checkout@v4
+
+        - name: Create file .env
+          run: echo "${{ secrets.ENVS_TESTS }}" > .env
+
+        - name: Configurar Python
+          uses: actions/setup-python@v5
+          with:
+            python-version: '3.9'
+
+        - name: Instalar o Playwright e o Chromium
+          run: |
+            pip install playwright
+            playwright install chromium
+            pip install python-dotenv
+
+        - name: Executar script de atualização
+          run: python ./src/scripts/testMainFlow.py

--- a/src/scripts/testMainFlow.py
+++ b/src/scripts/testMainFlow.py
@@ -41,7 +41,7 @@ def test_envio_declaracao(pagina):
         pagina.click('xpath=//*[@id="root"]/main/form/div[2]/div/button')
         sleep(2)
         file_chooser = fc.value
-        file_chooser.set_files("./28_08_2024_20_29_16_186-02_-_Museologia_Procopio_Resistencia_-_Retificadora.xlsx")
+        file_chooser.set_files("./src/tests/assets/museologico.xlsx")
     sleep(2)
     pagina.click('button.br-button.primary.mt-5')
     sleep(1)
@@ -96,7 +96,7 @@ def test_exclusao_declaracao(pagina):
 
 
 with sync_playwright() as p:
-    navegador = p.chromium.launch(headless=False)
+    navegador = p.chromium.launch()
     pagina = navegador.new_page()
     login_public(pagina, user, pwd)
     test_nova_declaracao(pagina)

--- a/src/scripts/testMainFlow.py
+++ b/src/scripts/testMainFlow.py
@@ -1,0 +1,105 @@
+from playwright.sync_api import sync_playwright
+from time import sleep
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+site_public = os.getenv("site_public")
+page_declaracao = os.getenv("page_declaracao")
+user = os.getenv("user")
+pwd = os.getenv("pwd")
+
+
+def login_public(pagina, user, pwd):
+    pagina.goto(site_public)
+    pagina.fill('xpath=//*[@id="email"]', user)
+    pagina.fill('xpath=//*[@id="password"]',pwd)
+    pagina.click('xpath=//*[@id="root"]/div[2]/div[1]/form/button')
+    sleep(3)
+    if pagina.is_visible('text="Minhas declarações"'):
+        print("Login realizado com sucesso!")
+    else:
+        print("Erro no login.")
+
+
+def test_nova_declaracao(pagina):
+    pagina.goto(page_declaracao)
+    sleep(3)
+    if pagina.is_visible('text=Nova declaração'):
+        print("Página de Nova declaração: Acessível")
+    else:
+        print("Página de Nova declaração: Inacessível")
+
+
+def test_envio_declaracao(pagina):
+    pagina.click('xpath=//*[@id="root"]/main/form/div[1]/div[3]/div[1]/button') 
+    sleep(1)
+    pagina.click('div.br-checkbox label:has-text("Museológico")') 
+    pagina.click('xpath=//*[@id="root"]/main/form/div[1]/div[3]/div[1]/button') 
+    with pagina.expect_file_chooser() as fc:
+        pagina.click('xpath=//*[@id="root"]/main/form/div[2]/div/button')
+        sleep(2)
+        file_chooser = fc.value
+        file_chooser.set_files("./28_08_2024_20_29_16_186-02_-_Museologia_Procopio_Resistencia_-_Retificadora.xlsx")
+    sleep(2)
+    pagina.click('button.br-button.primary.mt-5')
+    sleep(1)
+    pagina.click('button.br-button.primary.small.m-2')
+    sleep(2)
+    if pagina.is_visible('text="Declaração enviada com sucesso!"'):
+        print("Envio de declaração: Sucesso")
+    else:
+        print("Envio de declaração: Falhou")
+    pagina.click('text= Exibir') 
+    sleep(2)
+
+
+def test_retificacao(pagina):
+    pagina.click('text= Retificar') 
+    sleep(1)
+    pagina.click('xpath=//*[@id="root"]/main/form/div[1]/div[3]/div[1]/button') 
+    sleep(1)
+    pagina.click('div.br-checkbox label:has-text("Museológico")') 
+    pagina.click('xpath=//*[@id="root"]/main/form/div[1]/div[3]/div[1]/button') 
+    sleep(1)
+    with pagina.expect_file_chooser() as fc:
+        pagina.click('xpath=//*[@id="root"]/main/form/div[2]/div/button')
+        sleep(2)
+        file_chooser = fc.value
+        file_chooser.set_files("./28_08_2024_20_29_16_186-02_-_Museologia_Procopio_Resistencia_-_Retificadora.xlsx")
+    sleep(2)
+    pagina.click('button.br-button.primary.mt-5') 
+    pagina.click("button.br-button.primary.small.m-2") 
+    sleep(1)
+    if pagina.is_visible('text=Declaração retificadora'):
+        print("Declaração retificada: Sucesso")
+    else:
+        print("Declaração retificada: Falhou")
+    sleep(1)
+
+
+def test_exclusao_declaracao(pagina):
+    pagina.click('text= Excluir') 
+    sleep(1)
+    pagina.click('text=Confirmar')
+    sleep(2)
+    if pagina.is_visible('text=Declaração excluída com sucesso!'):
+        print("Exclusão de declaração: Sucesso\n")
+        print("""# Fluxo principal de:\n
+- Envio de declaração
+- Retificação
+- Exclusão
+    OK""")
+    else:
+        print("Exclusão de declaração: Falhou")
+
+
+with sync_playwright() as p:
+    navegador = p.chromium.launch(headless=False)
+    pagina = navegador.new_page()
+    login_public(pagina, user, pwd)
+    test_nova_declaracao(pagina)
+    test_envio_declaracao(pagina)
+    test_retificacao(pagina)
+    test_exclusao_declaracao(pagina)


### PR DESCRIPTION
Esse script de teste vai:
- Logar no site
- Acessa a aba de nova declaração
- Enviar um declaração 
- Retificar declaração
- Excluir declaração

Adição da actions
- Automatização de inicialização de teste após o update do portainer