### PR TITLE
Task id#427

### DIFF
--- a/src/models/Declaracao.ts
+++ b/src/models/Declaracao.ts
@@ -16,7 +16,7 @@ export interface Arquivo {
   analistasResponsaveis?: mongoose.Types.ObjectId[]
   analistasResponsaveisNome?: string[]
   porcentagemGeral?: number
-  porcentagemPorCampo?: Record<string, number>
+  porcentagemPorCampo?: { campo: string; percentual: number }[]
 }
 
 export interface TimeLine {
@@ -62,7 +62,12 @@ const ArquivoSchema = new Schema<Arquivo>(
     analistasResponsaveis: [{ type: Schema.Types.ObjectId, ref: "usuarios" }],
     analistasResponsaveisNome: [{ type: String }],
     porcentagemGeral: { type: Number, default: 0 },
-    porcentagemPorCampo: { type: Map, of: Number, default: {} }
+    porcentagemPorCampo: [
+      {
+        campo: { type: String, required: true },
+        percentual: { type: Number, required: true }
+      }
+    ]
   },
   { _id: false, versionKey: false }
 )

--- a/src/models/Declaracao.ts
+++ b/src/models/Declaracao.ts
@@ -15,6 +15,8 @@ export interface Arquivo {
   comentarios: string[]
   analistasResponsaveis?: mongoose.Types.ObjectId[]
   analistasResponsaveisNome?: string[]
+  porcentagemGeral?: number
+  porcentagemPorCampo?: Record<string, number>
 }
 
 export interface TimeLine {
@@ -58,7 +60,9 @@ const ArquivoSchema = new Schema<Arquivo>(
     versao: { type: Number, default: 0 },
     comentarios: [ComentarioSchema],
     analistasResponsaveis: [{ type: Schema.Types.ObjectId, ref: "usuarios" }],
-    analistasResponsaveisNome: [{ type: String }]
+    analistasResponsaveisNome: [{ type: String }],
+    porcentagemGeral: { type: Number, default: 0 },
+    porcentagemPorCampo: { type: Map, of: Number, default: {} }
   },
   { _id: false, versionKey: false }
 )

--- a/src/utils/calcularPercentual.ts
+++ b/src/utils/calcularPercentual.ts
@@ -3,23 +3,21 @@ export function calcularPercentuais(
   requiredFields: string[]
 ): {
   porcentagemGeral: number
-  porcentagemPorCampo: Record<string, number>
+  porcentagemPorCampo: { campo: string; percentual: number }[]
   errors: string[]
 } {
-  const totalCampos = Object.keys(arquivoData[0] || {}).length // Total de campos por linha
-  const totalLinhas = arquivoData.length // Total de linhas
-  const totalCamposEsperados = totalCampos * totalLinhas // Total de campos no arquivo
+  const totalCampos = Object.keys(arquivoData[0] || {}).length
+  const totalLinhas = arquivoData.length
+  const totalCamposEsperados = totalCampos * totalLinhas
 
-  let camposPreenchidos = 0 // Contador de campos preenchidos
-  const fieldCounts: Record<string, number> = {} // Contador de preenchimento por campo
-  const errors: string[] = [] // Campos obrigatórios não preenchidos
+  let camposPreenchidos = 0
+  const fieldCounts: Record<string, number> = {}
+  const errors: string[] = []
 
-  // Inicializa o contador de campos
   Object.keys(arquivoData[0] || {}).forEach((campo) => {
     fieldCounts[campo] = 0
   })
 
-  // Itera sobre cada linha
   arquivoData.forEach((linha) => {
     Object.entries(linha).forEach(([campo, valor]) => {
       if (valor) {
@@ -28,7 +26,6 @@ export function calcularPercentuais(
       }
     })
 
-    // Verifica campos obrigatórios
     requiredFields.forEach((campo) => {
       if (!linha[campo]) {
         errors.push(campo)
@@ -36,11 +33,12 @@ export function calcularPercentuais(
     })
   })
 
-  // Calcula o percentual de preenchimento por campo
-  const porcentagemPorCampo: Record<string, number> = {}
-  Object.entries(fieldCounts).forEach(([campo, count]) => {
-    porcentagemPorCampo[campo] = (count / totalLinhas) * 100
-  })
+  // Calcula o percentual de preenchimento por campo e converte em array
+  const porcentagemPorCampo: { campo: string; percentual: number }[] =
+    Object.entries(fieldCounts).map(([campo, count]) => ({
+      campo,
+      percentual: (count / totalLinhas) * 100
+    }))
 
   // Calcula o percentual de preenchimento geral
   const porcentagemGeral =
@@ -51,6 +49,6 @@ export function calcularPercentuais(
   return {
     porcentagemGeral,
     porcentagemPorCampo,
-    errors: Array.from(new Set(errors)) // Remove duplicatas
+    errors: Array.from(new Set(errors))
   }
 }

--- a/src/utils/calcularPercentual.ts
+++ b/src/utils/calcularPercentual.ts
@@ -1,0 +1,56 @@
+export function calcularPercentuais(
+  arquivoData: { [key: string]: string }[],
+  requiredFields: string[]
+): {
+  porcentagemGeral: number
+  porcentagemPorCampo: Record<string, number>
+  errors: string[]
+} {
+  const totalCampos = Object.keys(arquivoData[0] || {}).length // Total de campos por linha
+  const totalLinhas = arquivoData.length // Total de linhas
+  const totalCamposEsperados = totalCampos * totalLinhas // Total de campos no arquivo
+
+  let camposPreenchidos = 0 // Contador de campos preenchidos
+  const fieldCounts: Record<string, number> = {} // Contador de preenchimento por campo
+  const errors: string[] = [] // Campos obrigatórios não preenchidos
+
+  // Inicializa o contador de campos
+  Object.keys(arquivoData[0] || {}).forEach((campo) => {
+    fieldCounts[campo] = 0
+  })
+
+  // Itera sobre cada linha
+  arquivoData.forEach((linha) => {
+    Object.entries(linha).forEach(([campo, valor]) => {
+      if (valor) {
+        camposPreenchidos++
+        fieldCounts[campo]++
+      }
+    })
+
+    // Verifica campos obrigatórios
+    requiredFields.forEach((campo) => {
+      if (!linha[campo]) {
+        errors.push(campo)
+      }
+    })
+  })
+
+  // Calcula o percentual de preenchimento por campo
+  const porcentagemPorCampo: Record<string, number> = {}
+  Object.entries(fieldCounts).forEach(([campo, count]) => {
+    porcentagemPorCampo[campo] = (count / totalLinhas) * 100
+  })
+
+  // Calcula o percentual de preenchimento geral
+  const porcentagemGeral =
+    totalCamposEsperados > 0
+      ? (camposPreenchidos / totalCamposEsperados) * 100
+      : 0
+
+  return {
+    porcentagemGeral,
+    porcentagemPorCampo,
+    errors: Array.from(new Set(errors)) // Remove duplicatas
+  }
+}


### PR DESCRIPTION
## Adiciona seção de percentual de preenchimento por tipo de acervo no recibo

- Inclui nova seção no recibo para exibir o percentual de preenchimento dos campos da declaração.
- A seção é separada por tipo de acervo (museológico, bibliográfico, arquivístico), se presentes na declaração.
- Ajusta a lógica para garantir que a seção só apareça quando houver dados de preenchimento disponíveis para o respectivo tipo de acervo.
