### PR TITLE
Fix/horario sp anodeclaracao

### DIFF
--- a/src/controllers/AnoDeclaracaoController.ts
+++ b/src/controllers/AnoDeclaracaoController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express"
 import { AnoDeclaracao } from "../models/AnoDeclaracao"
 import logger from "../utils/logger"
+import { DataUtils } from "../utils/dataUtils"
 
 class AnoDeclaracaoController {
   /**
@@ -33,11 +34,11 @@ class AnoDeclaracaoController {
         metaDeclaracoesEnviadas
       } = req.body
 
-      // Convertendo as strings para objetos Date, se necessário
-      const dataInicioSubmissaoDate = new Date(dataInicioSubmissao)
-      const dataFimSubmissaoDate = new Date(dataFimSubmissao)
-      const dataInicioRetificacaoDate = new Date(dataInicioRetificacao)
-      const dataFimRetificacaoDate = new Date(dataFimRetificacao)
+      // Usando o helper DataUtils para formatar as datas
+      const dataInicioSubmissaoFormatada = DataUtils.gerarDataHoraFormatada(new Date(dataInicioSubmissao))
+      const dataFimSubmissaoFormatada = DataUtils.gerarDataHoraFormatada(new Date(dataFimSubmissao))
+      const dataInicioRetificacaoFormatada = DataUtils.gerarDataHoraFormatada(new Date(dataInicioRetificacao))
+      const dataFimRetificacaoFormatada = DataUtils.gerarDataHoraFormatada(new Date(dataFimRetificacao))
 
       const anoExistente = await AnoDeclaracao.findOne({ ano })
       if (anoExistente) {
@@ -48,10 +49,10 @@ class AnoDeclaracaoController {
 
       const anoDeclaracao = new AnoDeclaracao({
         ano,
-        dataInicioSubmissao: dataInicioSubmissaoDate,
-        dataFimSubmissao: dataFimSubmissaoDate,
-        dataInicioRetificacao: dataInicioRetificacaoDate,
-        dataFimRetificacao: dataFimRetificacaoDate,
+        dataInicioSubmissao: dataInicioSubmissaoFormatada,
+        dataFimSubmissao: dataFimSubmissaoFormatada,
+        dataInicioRetificacao: dataInicioRetificacaoFormatada,
+        dataFimRetificacao: dataFimRetificacaoFormatada,
         metaDeclaracoesEnviadas
       })
 

--- a/src/utils/dataUtils.ts
+++ b/src/utils/dataUtils.ts
@@ -13,4 +13,10 @@ export class DataUtils {
     const timeZone = "America/Sao_Paulo"
     return formatInTimeZone(data, timeZone, "HH:mm:ss")
   }
+
+  static gerarDataHoraFormatada(data: Date = this.getCurrentData()): string {
+    const timeZone = "America/Sao_Paulo"
+    // Formatar a data e a hora juntas no formato ISO
+    return formatInTimeZone(data, timeZone, "yyyy-MM-dd'T'HH:mm:ss")
+  }
 }


### PR DESCRIPTION
Ao criar um datetime nos períodos de AnoDeclaracao, coloca o horário padrão como São Paulo ao criar um objeto.