### PR TITLE
Feat/migration db

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "create:data": "sucrase-node src/scripts/generateMockData.ts",
     "insert:museus": "sucrase-node src/scripts/insertMuseusApiMuseusBr.ts",
     "create:permissions": "sucrase-node src/scripts/setPermissions.ts",
+"migration:db": "sucrase-node src/scripts/migrationDb.ts",
     "list:users": "sucrase-node src/scripts/listUsers.ts",
     "prepare": "[[ $NODE_ENV == 'development' ]] && husky install || true",
     "lint:fix": "eslint --cache --fix src",

--- a/src/scripts/migrationDb.ts
+++ b/src/scripts/migrationDb.ts
@@ -1,0 +1,75 @@
+import mongoose from "mongoose"
+import { AnoDeclaracao, Declaracoes } from "../models"
+import config from "../config"
+import logger from "../utils/logger"
+
+async function createAnoToObjectIdMap() {
+  const anoToObjectIdMap = new Map()
+
+  try {
+    const anosDeclaracao = await AnoDeclaracao.find({}, { ano: 1, _id: 1 })
+
+    for (const doc of anosDeclaracao) {
+      anoToObjectIdMap.set(doc.ano.toString(), doc._id)
+    }
+  } catch (error) {
+    logger.error("Erro ao criar mapa de ano para ObjectId:", error)
+  }
+
+  return anoToObjectIdMap
+}
+
+async function migrateAnoDeclaracao(anoToObjectIdMap) {
+  try {
+    const declaracoes = await Declaracoes.find({}).lean()
+
+    logger.info(`Iniciando migração para ${declaracoes.length} declarações...`)
+
+    for (const doc of declaracoes) {
+      const { _id, anoDeclaracao } = doc
+
+      if (anoDeclaracao && typeof anoDeclaracao === "string") {
+        const objectId = anoToObjectIdMap.get(anoDeclaracao)
+
+        if (objectId) {
+          await Declaracoes.updateOne(
+            { _id },
+            { $set: { anoDeclaracao: objectId } }
+          )
+        } else {
+          logger.warn(
+            `Sem ObjectId para o ano: ${anoDeclaracao} (Declaração ${_id})`
+          )
+        }
+      } else if (anoDeclaracao === undefined) {
+        logger.warn(`Declaração ${_id} tem anoDeclaracao undefined!`)
+      } else {
+        logger.warn(
+          `anoDeclaracao não é uma string: ${anoDeclaracao} (Declaração ${_id})`
+        )
+      }
+    }
+  } catch (error) {
+    logger.error("Erro durante a migração:", error)
+  }
+}
+
+async function main() {
+  try {
+    logger.info("🔗 Conectando ao banco de dados...")
+
+    await mongoose.connect(` ${config.DB_URL}`)
+
+    logger.info("Conexão estabelecida!")
+
+    const anoToObjectIdMap = await createAnoToObjectIdMap()
+
+    await migrateAnoDeclaracao(anoToObjectIdMap)
+  } catch (error) {
+    logger.error("Erro no processo principal:", error)
+  } finally {
+    await mongoose.disconnect()
+    logger.info("Conexão encerrada.")
+  }
+}
+main()


### PR DESCRIPTION
Migração do Campo `anoDeclaracao` para ObjectId

Este Pull Request realiza a migração do campo `anoDeclaracao` nas declarações de uma string para um `ObjectId`, referenciando a coleção `AnoDeclaracao`. O processo inclui:

- **Criação do mapa de anos**: A função `createAnoToObjectIdMap()` cria um mapa que mapeia o ano (string) para o seu respectivo `ObjectId` da coleção `AnoDeclaracao`.
- **Migração das declarações**: A função `migrateAnoDeclaracao()` percorre todas as declarações e, quando encontra um campo `anoDeclaracao` como string, o converte para o `ObjectId` correspondente.

## Feat

-   Função `createAnoToObjectIdMap()` para criar o mapa de anos para `ObjectId`.
-  Função `migrateAnoDeclaracao()` para realizar a migração dos dados na coleção `Declaracoes`.
