### PR TITLE
[feat]: add script para corrigir  estrutura do museu schema

### DIFF
--- a/src/scripts/corrigirMuseus.ts
+++ b/src/scripts/corrigirMuseus.ts
@@ -1,0 +1,34 @@
+import connect from "../db/conn"
+import { Museu } from "../models/Museu"
+import logger from "../utils/logger"
+
+const corrigirMuseus = async () => {
+  await connect()
+
+  try {
+    const result = await Museu.updateMany(
+      { usuario: { $exists: true, $not: { $type: "array" } } },
+      [
+        {
+          $set: {
+            usuario: {
+              $cond: {
+                if: { $eq: [{ $type: "$usuario" }, "array"] },
+                then: "$usuario",
+                else: ["$usuario"]
+              }
+            }
+          }
+        }
+      ]
+    )
+
+    logger.info(`Documentos corrigidos: ${result.modifiedCount}`)
+    process.exit(0)
+  } catch (error) {
+    logger.error("Erro ao corrigir documentos na coleção 'museus':", error)
+    process.exit(1)
+  }
+}
+
+corrigirMuseus()


### PR DESCRIPTION
# 🛠️ Corrige estrutura do campo `usuario` em `Museu`

## 📌 Descrição  
Este PR corrige a estrutura do campo `usuario` na coleção `museus`. Antes, o script de atualização sobrescrevia o valor existente, removendo a referência do usuário ao definir `usuario: []`. Agora, o script preserva os valores antigos e os converte corretamente para um array.

## 🔄 O que foi alterado?  
- Adicionada uma verificação para garantir que `usuario` seja um array sem perder os valores existentes.
- Utilizado `$set` com `$cond` para manter valores antigos e converter `usuario` corretamente.
- Melhor tratamento para evitar sobrescrita indesejada de dados.


